### PR TITLE
fix invalid litterals

### DIFF
--- a/internal/lexer/LexFn.go
+++ b/internal/lexer/LexFn.go
@@ -35,7 +35,7 @@ func LexKeyQuery(lexer *Lexer) LexFn {
 	if strings.ContainsRune(lexertoken.KEYS, lexer.Input[lexer.Start]) {
 		lexer.Emit(lexertoken.TOKEN_KEY)
 		return LexKeyQuery
-	} else if lexer.Input[lexer.Start] == '/n' {
+	} else if lexer.Input[lexer.Start] == `/n` {
 		return LexError
 	}
 	return LexEnd // To check, bad shit could be afterwards
@@ -121,7 +121,7 @@ func LexResult(lexer *Lexer) LexFn {
 		}
 	}
 	lexer.Inc()
-	if lexer.Input[lexer.Start] == '/n'
+	if lexer.Input[lexer.Start] == `/n` {
 		lexer.Emit(lexertoken.TOKEN_EOL)
 		return LexBegin
 	}

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -1,7 +1,6 @@
 package lexer
 
 import (
-	"unicode/utf8"
 	"unicode"
 )
 


### PR DESCRIPTION
"/n" should be escaped as "\\n" or specified as a raw string litteral as `\n`